### PR TITLE
fix: add default export for RemoteMCPClient

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,9 @@
 
 import { RemoteMCPClient } from './client.js';
 
+export { RemoteMCPClient } from './client.js';
+export default RemoteMCPClient;
+
 const client = new RemoteMCPClient({
   remoteUrl: process.env.REMOTE_URL || 'http://localhost:9512',
   headers: Object.keys(process.env)


### PR DESCRIPTION
## Summary
- Fixes issue #5 by adding proper default and named exports for RemoteMCPClient
- Created a test repo to verify the fix: https://github.com/actus-wirtenberger/remote-mcp-import-test

## Test plan
- Fix has been tested and confirmed working with both import styles:
  ```javascript
  // Default import
  import RemoteMCPClient from "@remote-mcp/client";
  
  // Named import
  import { RemoteMCPClient as NamedClient } from "@remote-mcp/client";
  ```