### PR TITLE
fix: env var naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Just put the following code in your MCP client settings, in here I'm using Claud
       "args": ["-y", "@remote-mcp/client"],
       "env": {
         "REMOTE_MCP_URL": "http://localhost:9512",
-        "HTTP_HEADER__Authorization": "Bearer <token>"
+        "HTTP_HEADER_Authorization": "Bearer <token>"
       }
     }
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,7 +6,7 @@ export { RemoteMCPClient } from './client.js';
 export default RemoteMCPClient;
 
 const client = new RemoteMCPClient({
-  remoteUrl: process.env.REMOTE_URL || 'http://localhost:9512',
+  remoteUrl: process.env.REMOTE_MCP_URL || 'http://localhost:9512',
   headers: Object.keys(process.env)
     .filter((key) => key.startsWith('HTTP_HEADER_'))
     .reduce(


### PR DESCRIPTION
Fixes inconsistencies between code and documentation regarding environment variable names and formats.